### PR TITLE
Update Cargo.toml

### DIFF
--- a/lol_alloc/Cargo.toml
+++ b/lol_alloc/Cargo.toml
@@ -11,7 +11,7 @@ categories = ["memory-management", "web-programming", "no-std", "wasm"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-spin = "0.9.4"
+spin = "0.9.8"
 
 [dev-dependencies]
 wasm-bindgen-test = "0.3.0"


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)