### PR TITLE
Avoid assertion messages in free_list_allocator in release builds.

### DIFF
--- a/lol_alloc/src/free_list_allocator.rs
+++ b/lol_alloc/src/free_list_allocator.rs
@@ -176,11 +176,11 @@ fn full_size(layout: Layout) -> usize {
 fn round_up(value: usize, increment: usize) -> usize {
     debug_assert!(increment.is_power_of_two());
 
-    // This effectively computes `value.div_ceil(increment) * increment`,
-    // but in a way that takes advantage of the fact that `increment` is
+    // Compute `value.div_ceil(increment) * increment`,
+    // in a way that takes advantage of the fact that `increment` is
     // always a power of two to avoid using an integer divide, since that
     // wouldn't always get optimized out.
-    (value + (increment - 1)) & increment.wrapping_neg()
+    multiple_below(value + (increment - 1), increment)
 }
 
 /// Round down value to the nearest multiple of increment, which must be a
@@ -189,7 +189,7 @@ fn round_up(value: usize, increment: usize) -> usize {
 fn multiple_below(value: usize, increment: usize) -> usize {
     debug_assert!(increment.is_power_of_two());
 
-    // This effectively computes `value / increment * increment`, but in a way
+    // Compute `value / increment * increment` in a way
     // that takes advantage of the fact that `increment` is always a power of
     // two to avoid using an integer divide, since that wouldn't always get
     // optimized out.

--- a/lol_alloc/src/free_list_allocator.rs
+++ b/lol_alloc/src/free_list_allocator.rs
@@ -170,15 +170,27 @@ fn full_size(layout: Layout) -> usize {
     round_up(grown, NODE_SIZE)
 }
 
-// From https://github.com/wackywendell/basicalloc/blob/0ad35d6308f70996f5a29b75381917f4cbfd9aef/src/allocators.rs
-// Round up value to the nearest multiple of increment
+/// Round up value to the nearest multiple of increment, which must be a
+/// power of 2.
 fn round_up(value: usize, increment: usize) -> usize {
     debug_assert!(increment.is_power_of_two());
+
+    // This effectively computes `value.div_ceil(increment) * increment`,
+    // but in a way that takes advantage of the fact that `increment` is
+    // always a power of two to avoid using an integer divide, since that
+    // wouldn't always get optimized out.
     (value + (increment - 1)) & increment.wrapping_neg()
 }
 
+/// Round down value to the nearest multiple of increment, which must be a
+/// power of 2.
 fn multiple_below(value: usize, increment: usize) -> usize {
     debug_assert!(increment.is_power_of_two());
+
+    // This effectively computes `value / increment * increment`, but in a way
+    // that takes advantage of the fact that `increment` is always a power of
+    // two to avoid using an integer divide, since that wouldn't always get
+    // optimized out.
     value & increment.wrapping_neg()
 }
 

--- a/lol_alloc/src/free_list_allocator.rs
+++ b/lol_alloc/src/free_list_allocator.rs
@@ -171,7 +171,8 @@ fn full_size(layout: Layout) -> usize {
 }
 
 /// Round up value to the nearest multiple of increment, which must be a
-/// power of 2.
+/// power of 2. If `value` is a multiple of increment, it is returned
+/// unchanged.
 fn round_up(value: usize, increment: usize) -> usize {
     debug_assert!(increment.is_power_of_two());
 
@@ -183,7 +184,8 @@ fn round_up(value: usize, increment: usize) -> usize {
 }
 
 /// Round down value to the nearest multiple of increment, which must be a
-/// power of 2.
+/// power of 2. If `value` is a multiple of `increment`, it is returned
+/// unchanged.
 fn multiple_below(value: usize, increment: usize) -> usize {
     debug_assert!(increment.is_power_of_two());
 
@@ -201,7 +203,8 @@ unsafe fn offset_bytes(ptr: *mut FreeListNode, offset: usize) -> *mut FreeListNo
 #[cfg(test)]
 mod tests {
     use super::{
-        multiple_below, FreeListAllocator, MemoryGrower, PageCount, EMPTY_FREE_LIST, NODE_SIZE,
+        multiple_below, round_up, FreeListAllocator, MemoryGrower, PageCount, EMPTY_FREE_LIST,
+        NODE_SIZE,
     };
     use crate::{ERROR_PAGE_COUNT, PAGE_SIZE};
     use alloc::{boxed::Box, vec::Vec};
@@ -287,6 +290,19 @@ mod tests {
             }
         }
         out
+    }
+
+    #[test]
+    fn round_up_works() {
+        assert_eq!(round_up(0, 8), 0);
+        assert_eq!(round_up(7, 8), 8);
+        assert_eq!(round_up(8, 8), 8);
+        assert_eq!(round_up(9, 8), 16);
+        assert_eq!(round_up(15, 8), 16);
+        assert_eq!(round_up(16, 8), 16);
+
+        assert_eq!(round_up(127, 128), 128);
+        assert_eq!(round_up(100223, 128), 100224);
     }
 
     #[test]


### PR DESCRIPTION
Change some `assert`s to `debug_assert`s, for smaller code size in release builds.

And, avoid doing an integer divison in `round_up` and `multiple_below`, by taking advantage of the fact that the denominator is always a power of two. These functions are often inlined, in which case the optimizer can see the powers of two and do this optimization itself, however this isn't always done when optimizing for size.